### PR TITLE
Revert "chore(deps): bump actions/upload-pages-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Build Website with Jekyll
         uses: actions/jekyll-build-pages@v1
       - name: Upload Website to GitHub Artifacts
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The `.well-known` path was lost after that PR. Due to https://github.com/actions/upload-pages-artifact/pull/102.
An issue was opened in the upstream repository: https://github.com/actions/upload-pages-artifact/issues/129.

Reverts scala-workshop/workshop.scala-lang.org#38